### PR TITLE
Add load_model convenience function

### DIFF
--- a/cellx/core.py
+++ b/cellx/core.py
@@ -20,7 +20,7 @@ def _get_custom_layers_dict() -> dict:
 
 
 def load_model(filename: str, **kwargs) -> K.Model:
-    """Convenience function load a Keras model with custom cellx layers.
+    """Convenience function to load a Keras model with custom cellx layers.
 
     Parameters
     ----------

--- a/cellx/core.py
+++ b/cellx/core.py
@@ -1,2 +1,37 @@
-def example_function() -> str:
-    return 'hello world'
+import inspect
+
+from tensorflow import keras as K
+
+
+def _get_custom_layers_dict() -> dict:
+    """Find custom cellx layers and return a dictionary with the layer name and
+    layer.
+
+    Returns
+    -------
+    custom_objects : dict[str, layer]
+
+    """
+    from . import layers
+
+    objects = inspect.getmembers(layers, inspect.isclass)
+    custom_objects = {k: v for k, v in objects if issubclass(v, K.layers.Layer)}
+    return custom_objects
+
+
+def load_model(filename: str, **kwargs) -> K.Model:
+    """Convenience function load a Keras model with custom cellx layers.
+
+    Parameters
+    ----------
+    filename : str
+        Filename for the model.
+
+    Returns
+    -------
+    model : keras.Model
+        The model.
+    """
+    custom_objects = _get_custom_layers_dict()
+    model = K.models.load_model(filename, custom_objects=custom_objects, **kwargs)
+    return model


### PR DESCRIPTION
This PR adds a convenience function to load keras models that have been created with custom cellx layers, and closes #10 . It can be used in the same manner as the normal keras `load_model`, e.g.:

```python 
import cellx
model = cellx.load_model('decoder.h5')
```