### PR TITLE
Fix #14: change manifold indexing

### DIFF
--- a/cellx/tools/projection.py
+++ b/cellx/tools/projection.py
@@ -65,7 +65,24 @@ class ManifoldProjection2D:
     def __call__(
         self, manifold: np.ndarray, bins: int = 32, components: tuple = (0, 1)
     ) -> tuple:
-        """Build the projection."""
+        """Build the projection.
+
+        Parameters
+        ----------
+        manifold : np.ndarray
+            Numpy array of the manifold projection.
+        bins : int
+            Number of two-dimensional bins to group the manifold examples in.
+        components : tuple of int
+            Dimensions of the manifold projection.
+
+        Returns
+        -------
+        imgrid : np.ndarray
+            A grid to assign image patches to.
+        extent : list of float
+            Delimiting bin edge values that allow to map onto the 2D projection.
+        """
 
         assert manifold.shape[0] == len(self._images)
 
@@ -125,8 +142,6 @@ class ManifoldProjection2D:
 
             imgrid[blockx, blocky, :] = im
 
-        # return the extent, i.e. the mapping back to the components of the
-        # manifold
         extent = [min(xe), max(xe), min(ye), max(ye)]
 
         return imgrid, extent

--- a/cellx/tools/projection.py
+++ b/cellx/tools/projection.py
@@ -79,9 +79,11 @@ class ManifoldProjection2D:
         Returns
         -------
         imgrid : np.ndarray
-            An image with example image patches from the manifold arranged on a grid.
-        extent : list of float
-            Delimits the minimum and maximum bin edges, in each dimension, used to create the result.
+            An image with example image patches from the manifold arranged on a
+            grid.
+        extent : tuple
+            Delimits the minimum and maximum bin edges, in each dimension, used
+            to create the result.
         """
 
         assert manifold.shape[0] == len(self._images)
@@ -142,7 +144,7 @@ class ManifoldProjection2D:
 
             imgrid[blockx, blocky, :] = im
 
-        extent = [min(xe), max(xe), min(ye), max(ye)]
+        extent = (min(xe), max(xe), min(ye), max(ye))
 
         return imgrid, extent
 

--- a/cellx/tools/projection.py
+++ b/cellx/tools/projection.py
@@ -74,14 +74,14 @@ class ManifoldProjection2D:
         bins : int
             Number of two-dimensional bins to group the manifold examples in.
         components : tuple of int
-            Dimensions of the manifold projection.
+            Dimensions of manifold to use when creating the projection.
 
         Returns
         -------
         imgrid : np.ndarray
-            A grid to assign image patches to.
+            An image with example image patches from the manifold arranged on a grid.
         extent : list of float
-            Delimiting bin edge values that allow to map onto the 2D projection.
+            Delimits the minimum and maximum bin edges, in each dimension, used to create the result.
         """
 
         assert manifold.shape[0] == len(self._images)

--- a/cellx/tools/projection.py
+++ b/cellx/tools/projection.py
@@ -71,8 +71,8 @@ class ManifoldProjection2D:
 
         # bin the manifold
         s, xe, ye, bn = binned_statistic_2d(
-            manifold[:, 0],
-            manifold[:, 1],
+            manifold[:, components[0]],
+            manifold[:, components[1]],
             [],
             bins=bins,
             statistic="count",


### PR DESCRIPTION
Fix #14 - Index into manifold using `components` tuple rather than having it hard-coded