### PR TITLE
Added annotation file reader

### DIFF
--- a/cellx/tools/io.py
+++ b/cellx/tools/io.py
@@ -194,12 +194,17 @@ def read_annotations(path: str):
 
     Returns
     -------
-    images : np.ndarray
-        An array of N image patches of the format N,(Z),X,Y,C
-    labels : np.ndarray
-        An array of numeric image labels of size (N, )
+    images : list
+        A list of N image patches of the format (Z),Y,X,C
+    labels : list
+        A list of numeric image labels of length (N, )
     states : dict
         A dictionary mapping a string label to the numeric image label
+
+
+    Notes
+    -----
+    Should this raise a warning if the image patches are of different dimensions?
     """
 
     images = []
@@ -208,18 +213,18 @@ def read_annotations(path: str):
 
     # find the zip files:
     zipfiles = [
-        os.path.join(path, f)
-        for f in os.listdir(path)
-        if f.endswith(".zip") and f.startswith("annotation_")
+        os.path.join(path, filename)
+        for filename in os.listdir(path)
+        if filename.endswith(".zip") and filename.startswith("annotation_")
     ]
 
-    if len(zipfiles) == 0:
+    if not zipfiles:
         raise IOError("Warning, no 'annotation' zip files found.")
 
     # iterate over the zip files and aggregate the data
-    for zfn in zipfiles:
+    for zip_fn in zipfiles:
 
-        with zipfile.ZipFile(zfn, "r") as zip_data:
+        with zipfile.ZipFile(zip_fn, "r") as zip_data:
             files = zip_data.namelist()
 
             # first open the annotation file
@@ -238,25 +243,21 @@ def read_annotations(path: str):
                 if states != _states:
                     raise Exception("Annotation files are incompatible")
 
+            # now iterate over examples of each label type
             for state in States:
-
                 numeric_label = state.value
                 label = state.name
 
-                patch_files = [
-                    f for f in files if f.endswith(".tif") and f.startswith(label)
+                raw_images = [
+                    io.imread(zip_data.open(filename))
+                    for filename in files
+                    if filename.endswith(".tif") and filename.startswith(label)
                 ]
-
-                raw_images = [io.imread(zip_data.open(f)) for f in patch_files]
-                # images_resized = [resize(img, (64, 64), preserve_range=True) for img in images]
 
                 images += raw_images
                 labels += [numeric_label] * len(raw_images)
 
-    images_arr = np.stack(images, axis=0)[..., np.newaxis]
-    labels_arr = np.stack(labels, axis=0)
-
     # sanity check that we have the same number of labels and images
-    assert images_arr.shape[0] == labels_arr.shape[0]
+    assert len(images) == len(labels), "Number of labels and images are different"
 
-    return images_arr, labels_arr, states
+    return images, labels, states

--- a/cellx/tools/io.py
+++ b/cellx/tools/io.py
@@ -1,6 +1,8 @@
+import enum
 import hashlib
 import json
 import os
+import zipfile
 
 import numpy as np
 from skimage import io
@@ -176,3 +178,85 @@ class EncodingReader:
         stack = np.rollaxis(stack, 1, 4)
 
         return stack, metadata
+
+
+def read_annotations(path: str):
+    """Read annotations.
+
+    This provides a capability to load the contents of a single, or multiple
+    annotation files, aggregating their contents and returning a dictionary of
+    state labels.
+
+    Parameters
+    ----------
+    path : str
+        The path to the folder containing the annotation.zip files
+
+    Returns
+    -------
+    images : np.ndarray
+        An array of N image patches of the format N,(Z),X,Y,C
+    labels : np.ndarray
+        An array of numeric image labels of size (N, )
+    states : dict
+        A dictionary mapping a string label to the numeric image label
+    """
+
+    images = []
+    labels = []
+    states = {}
+
+    # find the zip files:
+    zipfiles = [
+        os.path.join(path, f)
+        for f in os.listdir(path)
+        if f.endswith(".zip") and f.startswith("annotation_")
+    ]
+
+    if len(zipfiles) == 0:
+        raise IOError("Warning, no 'annotation' zip files found.")
+
+    # iterate over the zip files and aggregate the data
+    for zfn in zipfiles:
+
+        with zipfile.ZipFile(zfn, "r") as zip_data:
+            files = zip_data.namelist()
+
+            # first open the annotation file
+            json_fn = [f for f in files if f.endswith(".json")][0]
+            with zip_data.open(json_fn) as js:
+                json_data = json.load(js)
+                _states = json_data["states"]
+
+                # if we have no states defined, use the serialized states to
+                # define them
+                if not states:
+                    states = _states
+                    States = enum.Enum("States", states)
+
+                # if they do exist, make sure that they match all other files
+                if states != _states:
+                    raise Exception("Annotation files are incompatible")
+
+            for state in States:
+
+                numeric_label = state.value
+                label = state.name
+
+                patch_files = [
+                    f for f in files if f.endswith(".tif") and f.startswith(label)
+                ]
+
+                raw_images = [io.imread(zip_data.open(f)) for f in patch_files]
+                # images_resized = [resize(img, (64, 64), preserve_range=True) for img in images]
+
+                images += raw_images
+                labels += [numeric_label] * len(raw_images)
+
+    images_arr = np.stack(images, axis=0)[..., np.newaxis]
+    labels_arr = np.stack(labels, axis=0)
+
+    # sanity check that we have the same number of labels and images
+    assert images_arr.shape[0] == labels_arr.shape[0]
+
+    return images_arr, labels_arr, states


### PR DESCRIPTION
This provides a convenience function in cellx to load annotation files created in napari.
See related PR here: https://github.com/lowe-lab-ucl/cnn-annotator/pull/18