### PR TITLE
Modify read_annotations for single zip files

### DIFF
--- a/cellx/tools/io.py
+++ b/cellx/tools/io.py
@@ -3,7 +3,7 @@ import hashlib
 import json
 import os
 import zipfile
-from typing import Union
+from typing import List, Union
 
 import imageio
 import numpy as np
@@ -182,7 +182,7 @@ class EncodingReader:
         return stack, metadata
 
 
-def read_annotations(path: Union[str, list], use_flagged: bool = False):
+def read_annotations(path: Union[str, List[str]], use_flagged: bool = False):
     """Read annotations.
 
     This provides a capability to load the contents of a single, or multiple

--- a/cellx/tools/io.py
+++ b/cellx/tools/io.py
@@ -235,20 +235,24 @@ def read_annotations(path: Union[str, List[str]], use_flagged: bool = False):
         ]
 
     if isinstance(path, list):
-        zipfiles = [
-            filename
-            for filename in path
-            if filename.split("/")[-1]
-            in os.listdir(("/").join(filename.split("/")[:-1]))
-            and filename.split("/")[-1].startswith("annotation_")
-            and filename.endswith(".zip")
-        ]
+        zipfiles = path
 
     if not zipfiles:
         raise IOError("Warning, no 'annotation' zip files found.")
 
     # iterate over the zip files and aggregate the data
     for zip_fn in zipfiles:
+
+        # check whether file is in the directory:
+        zip_path, zip_file = os.path.split(zip_fn)
+        if zip_file not in os.listdir(zip_path):
+            print(f"No '{zip_file}' in the directory: '{zip_path}'")
+            continue
+
+        # check whether file in the correct format;
+        if not zip_file.startswith("annotation_") and zip_file.endswith(".zip"):
+            print(f"Zip file in incorrect format: '{zip_file}'")
+            continue
 
         with zipfile.ZipFile(zip_fn, "r") as zip_data:
             files = zip_data.namelist()


### PR DESCRIPTION
Resolve #29 

Adds the `Union[str, List[str]]` option to specify either the path directory of zip files (`str`, in which case all zip files in the path are loaded) or a `List[str]` of concrete zip file(s) paths:

https://github.com/KristinaUlicna/cellx/blob/4d933ca5ac2e3489dac998bd21b00e6efa1e3ba9/cellx/tools/io.py#L185