### PR TITLE
Fix PosixPath error that occurs when running `build_dataset()`

### DIFF
--- a/_tests/test_dataset.py
+++ b/_tests/test_dataset.py
@@ -55,7 +55,7 @@ def test_read_write_dataset_dtype(tmp_path, dtype):
 def test_list_tfrecords(tmp_path):
     """Check that list_tfrecords returns a list of tfrecord files when using
     different inputs, e.g. single file, folder or list."""
-    filename = Path(tmp_path) / "test.tfrecord"
+    filename = str(Path(tmp_path) / "test.tfrecord")
     _ = _test_write_images(filename)
 
     # single path to file

--- a/cellx/tools/dataset.py
+++ b/cellx/tools/dataset.py
@@ -147,17 +147,17 @@ def per_channel_normalize(x: tf.Tensor) -> tf.Tensor:
 
 def list_tfrecord_files(
     files: Union[List[os.PathLike], os.PathLike],
-) -> List[os.PathLike]:
+) -> List[str]:
     """Parse the input into the list of files ending with '.tfrecord'.
 
     Parameters
     ----------
-    files : List[os.PathLike] or os.PathLike
-        Parse a list or single pathlike objects
+    files : list[os.PathLike] or os.PathLike
+        Parse a list or single pathlike objects.
 
     Returns
     -------
-    files : List[os.PathLike]
+    files : list[str]
         A TF compatible list of paths to `.tfrecord` files.
 
     """
@@ -172,12 +172,12 @@ def list_tfrecord_files(
     return files
 
 
-def build_dataset(files: Union[List[os.PathLike], os.PathLike], **kwargs):
+def build_dataset(files: List[str], **kwargs):
     """Build a TF Dataset from a list of TFRecordFiles. Map the parser to it.
 
     Parameters
     ----------
-    files : str, list[str]
+    files : list[str]
         The list of TFRecord files to use for the dataset.
 
     Returns

--- a/cellx/tools/dataset.py
+++ b/cellx/tools/dataset.py
@@ -167,6 +167,8 @@ def list_tfrecord_files(
             files = [f for f in files.iterdir() if f.suffix == ".tfrecord"]
         else:
             files = [files]
+    # convert PosixPath objects to strings to prevent errors in some TF versions
+    files = [str(f) for f in files]
     return files
 
 


### PR DESCRIPTION
Convert PosixPath objects to strings so that `tf.data.TFRecordDataset(tfrecordfiles)` doesn't throw an error for some (older) TF versions