### PR TITLE
modified image boundary augmentation

### DIFF
--- a/_tests/test_augmentation.py
+++ b/_tests/test_augmentation.py
@@ -5,10 +5,117 @@ import pytest
 import tensorflow as tf
 
 from cellx.augmentation.image import (
+    augment_random_boundary,
     augment_random_noise,
     augment_random_rot,
     augment_random_translation,
 )
+
+expected_outputs_boundary = [
+    np.array(
+        [
+            [0.0, 0.0, 8.2, 1.4],
+            [0.0, 0.0, 5.2, 4.2],
+            [0.0, 0.0, 1.3, 3.8],
+            [0.0, 0.0, 7.4, 3.2],
+        ],
+        dtype=np.float32,
+    ),
+    np.array(
+        [
+            [3.6, 7.1, 8.2, 0.0],
+            [0.3, 1.5, 5.2, 0.0],
+            [9.8, 8.5, 1.3, 0.0],
+            [2.2, 1.2, 7.4, 0.0],
+        ],
+        dtype=np.float32,
+    ),
+    np.array(
+        [
+            [0.0, 0.0, 0.0, 0.0],
+            [0.0, 0.0, 0.0, 0.0],
+            [0.0, 0.0, 0.0, 0.0],
+            [2.2, 1.2, 7.4, 3.2],
+        ],
+        dtype=np.float32,
+    ),
+    np.array(
+        [
+            [3.6, 7.1, 8.2, 1.4],
+            [0.3, 1.5, 5.2, 4.2],
+            [9.8, 8.5, 1.3, 3.8],
+            [2.2, 1.2, 7.4, 3.2],
+        ],
+        dtype=np.float32,
+    ),
+]
+
+
+@pytest.mark.parametrize(
+    "n,width,k",
+    [(0, [0.5], [1]), (1, [0.25], [3]), (2, [0.75], [0]), (3, [0.0], [0])],
+)
+def test_augment_random_boundary(n, width, k):
+    img = np.array(
+        [
+            [3.6, 7.1, 8.2, 1.4],
+            [0.3, 1.5, 5.2, 4.2],
+            [9.8, 8.5, 1.3, 3.8],
+            [2.2, 1.2, 7.4, 3.2],
+        ],
+        dtype=np.float32,
+    )
+    with patch(
+        "tensorflow.random.uniform",
+        side_effect=[tf.constant(width), tf.constant(k)],
+    ):
+        augmented = augment_random_boundary(img[tf.newaxis, ..., tf.newaxis])[
+            0, ..., 0
+        ]
+    expected = expected_outputs_boundary[n]
+    assert np.allclose(augmented, expected, atol=0.01)
+
+
+expected_outputs_boundary_stack = [
+    np.array(
+        [
+            [
+                [3.6, 7.1, 8.2, 0.0],
+                [0.3, 1.5, 5.2, 0.0],
+                [9.8, 8.5, 1.3, 0.0],
+                [2.2, 1.2, 7.4, 0.0],
+            ],
+            [
+                [0.0, 0.0, 0.0, 0.0],
+                [0.0, 0.0, 0.0, 0.0],
+                [0.0, 0.0, 0.0, 0.0],
+                [2.2, 1.2, 7.4, 3.2],
+            ],
+        ],
+        dtype=np.float32,
+    ),
+]
+
+
+@pytest.mark.parametrize("n,width,k", [(0, [0.25, 0.75], [3, 0])])
+def test_augment_random_boundary_stack(n, width, k):
+    img = np.array(
+        [
+            [3.6, 7.1, 8.2, 1.4],
+            [0.3, 1.5, 5.2, 4.2],
+            [9.8, 8.5, 1.3, 3.8],
+            [2.2, 1.2, 7.4, 3.2],
+        ],
+        dtype=np.float32,
+    )
+    img = np.stack([img] * 2, axis=0)
+    with patch(
+        "tensorflow.random.uniform",
+        side_effect=[tf.constant(width), tf.constant(k)],
+    ):
+        augmented = augment_random_boundary(img[..., tf.newaxis])[..., 0]
+    expected = expected_outputs_boundary_stack[n]
+    assert np.allclose(augmented, expected, atol=0.01)
 
 
 def test_augment_random_noise():


### PR DESCRIPTION
- Adapted image boundary aug from numpy to tensorflow, allowing for use in a TF graph context
- Updated the function such that the crop can occur from all four directions, instead of just one
- Added tests
- Allows for use of non-square image inputs
- Applies operation independently to images in a stack